### PR TITLE
Modularize GCE instance for reusability in gcp-compute-engine WIP

### DIFF
--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -19,68 +19,11 @@ provider "google" {
 # This code is compatible with Terraform 4.25.0 and versions that are backwards compatible to 4.25.0.
 # For information about validating this Terraform code, see https://developer.hashicorp.com/terraform/tutorials/gcp-get-started/google-cloud-platform-build#format-and-validate-the-configuration
 
-# EC instance
-resource "google_compute_instance" "instance-20240922-191308" {
-  boot_disk {
-    auto_delete = true
-    device_name = "instance-20240922-191308"
+module "pplox-web-deployment" {
+  source = "../modules/gcp-compute-engine"
 
-    initialize_params {
-      image = "projects/ubuntu-os-cloud/global/images/ubuntu-2404-noble-amd64-v20240911"
-      size  = 10
-      type  = "pd-balanced"
-    }
-
-    mode = "READ_WRITE"
-  }
-
-  can_ip_forward      = false
-  deletion_protection = false
-  enable_display      = false
-
-  labels = {
-    goog-ec-src           = "vm_add-tf"
-    goog-ops-agent-policy = "v2-x86-template-1-3-0"
-  }
-
-  machine_type = "e2-micro"
-
-  metadata = {
-    enable-osconfig = "TRUE"
-  }
-
-  name = "instance-20240922-191308"
-
-  network_interface {
-    access_config {
-      network_tier = "PREMIUM"
-    }
-
-    queue_count = 0
-    stack_type  = "IPV4_ONLY"
-    subnetwork  = "projects/poised-bot-273002/regions/us-central1/subnetworks/default"
-  }
-
-  scheduling {
-    automatic_restart   = true
-    on_host_maintenance = "MIGRATE"
-    preemptible         = false
-    provisioning_model  = "STANDARD"
-  }
-
-  service_account {
-    email  = "405787926076-compute@developer.gserviceaccount.com"
-    scopes = ["https://www.googleapis.com/auth/devstorage.read_only", "https://www.googleapis.com/auth/logging.write", "https://www.googleapis.com/auth/monitoring.write", "https://www.googleapis.com/auth/service.management.readonly", "https://www.googleapis.com/auth/servicecontrol", "https://www.googleapis.com/auth/trace.append"]
-  }
-
-  shielded_instance_config {
-    enable_integrity_monitoring = true
-    enable_secure_boot          = false
-    enable_vtpm                 = true
-  }
-
-  tags = ["http-server", "https-server"]
-  zone = "us-central1-f"
+  name = "pplox-web-deployment"
+  tags = ["tf", "dev"]
 }
 
 # Bucket

--- a/modules/gcp-compute-engine/.terraform.lock.hcl
+++ b/modules/gcp-compute-engine/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "4.51.0"
+  constraints = "4.51.0"
+  hashes = [
+    "h1:7JFdiV9bvV6R+AeWzvNbVeoega481sJY3PqtIbrwTsM=",
+    "zh:001bf7478e495d497ffd4054453c97ab4dd3e6a24d46496d51d4c8094e95b2b1",
+    "zh:19db72113552dd295854a99840e85678d421312708e8329a35787fff1baeed8b",
+    "zh:42c3e629ace225a2cb6cf87b8fabeaf1c56ac8eca6a77b9e3fc489f3cc0a9db5",
+    "zh:50b930755c4b1f8a01c430d8f688ea79de0b0198c87511baa3a783e360d7e624",
+    "zh:5acd67f0aafff5ad59e179543cccd1ffd48d69b98af0228506403b8d8193b340",
+    "zh:70128d57b4b4bf07df941172e6af15c4eda8396af5cc2b0128c906983c7b7fad",
+    "zh:7905fac0ba2becf0e97edfcd4224e57466b04f960f36a3ec654a0a3c2ffececb",
+    "zh:79b4cc760305cd77c1ff841f789184f808b8052e8f4faa5cb8d518e4c13beb22",
+    "zh:c7aebd7d7dd2b29de28e382500d36fae8b4d8a192cf05e41ea29c66f1251acfc",
+    "zh:d8b4494b13ef5af65d3afedf05bf7565918f1e31ad68ae0df81f5c3b12baf519",
+    "zh:e6e68ef6881bc3312db50c9fd761f226f34d7834b64f90d96616b7ca6b1daf34",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/modules/gcp-compute-engine/main.tf
+++ b/modules/gcp-compute-engine/main.tf
@@ -1,0 +1,36 @@
+# Taken from https://github.com/terraform-google-modules/terraform-google-vm/blob/master/modules/compute_instance/main.tf
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "4.51.0"
+    }
+  }
+}
+
+resource "google_compute_instance" "this" {
+  name         = var.name
+  machine_type = var.machine_type
+  zone         = var.zone
+
+  # Using default network interface inferred from the subnetwork
+  network_interface {
+    access_config {
+      network_tier = var.network_tier
+    }
+  }
+
+  boot_disk {
+    auto_delete = true
+
+    initialize_params {
+      image = var.boot_disk_image
+      size  = var.boot_disk_size
+      type  = var.boot_disk_type
+    }
+  }
+
+  tags = var.tags
+
+}
+

--- a/modules/gcp-compute-engine/main.tf
+++ b/modules/gcp-compute-engine/main.tf
@@ -1,4 +1,3 @@
-# Taken from https://github.com/terraform-google-modules/terraform-google-vm/blob/master/modules/compute_instance/main.tf
 terraform {
   required_providers {
     google = {

--- a/modules/gcp-compute-engine/outputs.tf
+++ b/modules/gcp-compute-engine/outputs.tf
@@ -1,0 +1,9 @@
+output "public_ip" {
+  description = "External IP address of the instance"
+  value       = google_compute_instance.this.network_interface[0].access_config[0].nat_ip
+}
+
+output "name" {
+  description = "The name of the GCE instance"
+  value       = google_compute_instance.this.name
+}

--- a/modules/gcp-compute-engine/variables.tf
+++ b/modules/gcp-compute-engine/variables.tf
@@ -13,7 +13,7 @@ variable "machine_type" {
 variable "zone" {
   description = "The zone that the GCE instance is created"
   type        = string
-  default     = "NORTHAMERICA-NORTHEAST2"
+  default     = "northamerica-northeast2-a"
 }
 
 variable "network_tier" {

--- a/modules/gcp-compute-engine/variables.tf
+++ b/modules/gcp-compute-engine/variables.tf
@@ -1,0 +1,47 @@
+variable "name" {
+  description = "Name of GCE instance"
+  type        = string
+  default     = ""
+}
+
+variable "machine_type" {
+  description = "Type of Compute Engine machine"
+  type        = string
+  default     = "e2-micro"
+}
+
+variable "zone" {
+  description = "The zone that the GCE instance is created"
+  type        = string
+  default     = "NORTHAMERICA-NORTHEAST2"
+}
+
+variable "network_tier" {
+  description = "Networking tier. Accepted values: 'PREMIUM' and 'STANDARD'"
+  type        = string
+  default     = "STANDARD"
+}
+
+variable "boot_disk_image" {
+  description = "The image from which to initialize this disk"
+  type        = string
+  default     = "projects/ubuntu-os-cloud/global/images/ubuntu-2404-noble-amd64-v20240911"
+}
+
+variable "boot_disk_size" {
+  description = "The size of the image in gigabytes"
+  type        = number
+  default     = 5
+}
+
+variable "boot_disk_type" {
+  description = "The GCE disk type. 'pd-standard', 'pd-balanced' or 'pd-ssd'"
+  type        = string
+  default     = "pd-balanced"
+}
+
+variable "tags" {
+  description = "A list of network tags "
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
Modularized GCE instance for reusability. The new module is called `gcp-compute-engine`. In the future, we'd like to host `pplox-web`, `go-psql-golinks`, and future projects on GCE and this streamlines the creation of new instances.

Some settings were abstracted away to use the default values GCE provides. In the future we'd want to implement code scanning to ensure security. Looking at [KICS](https://www.kics.io/index.html) to handle this.